### PR TITLE
bugfix - Updated pathToSelect for LOCATION.SINGLE

### DIFF
--- a/src/configs/parametersToMap.ts
+++ b/src/configs/parametersToMap.ts
@@ -56,7 +56,7 @@ export const parametersToMap: ParameterToMap[] = [
 	{
 		locationName: LOCATION.SINGLE,
 		selector: 'querySelector',
-		pathToSelect: '#repository-container-header > div.d-flex.mb-3.px-3.px-md-4.px-lg-5 > div > div > strong a',
+		pathToSelect: '#repository-container-header > div.d-flex.mb-3.px-3.px-lg-5 > div > div > strong a',
 		/*
 			for example: https://github.com/kas-elvirov/gloc
 		*/


### PR DESCRIPTION
Github updated their CSS classes, rendering the extention unusable. I fixed only the pathToSelect for LOCATION.SINGLE, didn't check if others were affected.